### PR TITLE
Allow lookup of the current machine, for client side compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The _second function_ does the IP-address lookup and takes these arguments:
 parameter | type     | required | description
 --------- | -------- | -------- | ----------------------------------
 service   | string   | no       | The service, same as above
-ip        | string   | yes      | The IPv4 or IPv6 address to lookup
+ip        | string   | yes      | The IPv4 or IPv6 address to lookup, or us the string 'me' for the current machine
 callback  | function | yes      | Your callback `function` to receive the data
 
 ```js

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The _second function_ does the IP-address lookup and takes these arguments:
 parameter | type     | required | description
 --------- | -------- | -------- | ----------------------------------
 service   | string   | no       | The service, same as above
-ip        | string   | yes      | The IPv4 or IPv6 address to lookup, or us the string 'me' for the current machine
+ip        | string   | yes      | The IPv4 or IPv6 address to lookup, or use the string 'me' for the current machine
 callback  | function | yes      | Your callback `function` to receive the data
 
 ```js


### PR DESCRIPTION
Allowing queries with an ip address of `'me'` permits look ups for the current machines. This allows this library to be used on the client in `browserify` based projects, where the local external ip address is not easily available.