### PR TITLE
Test(config): Use dynamic node versions on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
 language: node_js
 node_js:
-- '6'
-- '4'
+- 'node'
+- '--lts'


### PR DESCRIPTION
Travis CI will now always run the most recent LTS and stable node versions.

Based on https://github.com/creationix/nvm/pull/1070