### PR TITLE
Fix: Credentials can be optional for certain endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,14 @@ You can find both [*here*](https://www.maxmind.com/en/accounts/current/license-k
 
 ## Configuration
 
-parameter  | type   | default                   | description
-:----------|:-------|:--------------------------|:-----------
-userId     | string |                           | User ID
-licenseKey | string |                           | License key
-[ip]       | string | me                        | The IP address or 'me' for your current IP
-[service]  | string | city                      | `insights`, `country` or `city`
-[endpoint] | string | https://geoip.maxmind.com | Override endpoint url, include the protocol prefix
-[timeout]  | number | 5000                      | Request timeout in ms
+parameter    | type   | default                   | description
+:------------|:-------|:--------------------------|:-----------
+[userId]     | string |                           | User ID, optional for proxy endpoints
+[licenseKey] | string |                           | License key, optional for proxy endpoints
+[ip]         | string | me                        | The IP address or 'me' for your current IP
+[service]    | string | city                      | `insights`, `country` or `city`
+[endpoint]   | string | https://geoip.maxmind.com | Override endpoint url, include the protocol prefix
+[timeout]    | number | 5000                      | Request timeout in ms
 
 ```js
 {

--- a/geoip2ws.js
+++ b/geoip2ws.js
@@ -13,8 +13,8 @@ License:        Unlicense (public domain, see LICENSE file)
  *
  * @param   {object}  o
  *
- * @param   {string}  o.userId            Account user ID
- * @param   {string}  o.licenseKey        Account license key
+ * @param   {string}  [o.userId]          Account user ID
+ * @param   {string}  [o.licenseKey]      Account license key
  * @param   {string}  [o.ip='me']         IP-address, hostname or 'me' to look up
  * @param   {string}  [o.service='city']  Account service name
  * @param   {string}  [o.endpoint]        API hostname or url
@@ -25,8 +25,8 @@ License:        Unlicense (public domain, see LICENSE file)
 
 module.exports = async function geoip2ws ( {
 
-  userId,
-  licenseKey,
+  userId = null,
+  licenseKey = null,
   ip = 'me',
   service = 'city',
   endpoint = 'https://geoip.maxmind.com',
@@ -37,16 +37,20 @@ module.exports = async function geoip2ws ( {
   endpoint = endpoint.replace( /\/$/, '' );
   endpoint += `/geoip/v2.1/${service}/${ip}`;
 
-  const res = await fetch( endpoint, {
+  const options = {
     signal: AbortSignal.timeout( timeout ),
     headers: {
       'Accept': 'application/json',
       'Accept-Charset': 'UTF-8',
-      'Authorization': 'Basic ' + Buffer.from( `${userId}:${licenseKey}` ).toString( 'base64' ),
       'User-Agent': 'fvdm/nodejs-geoip2ws',
     },
-  } );
+  };
 
+  if ( userId && licenseKey ) {
+    options.headers.Authorization = 'Basic ' + Buffer.from( `${userId}:${licenseKey}` ).toString( 'base64' );
+  }
+
+  const res = await fetch( endpoint, options );
   const data = await res.json();
 
   // Process API error

--- a/test.js
+++ b/test.js
@@ -115,6 +115,27 @@ doTest.add( 'lookup - IP without subdivisions (Japan)', async test => {
 } );
 
 
+// Optional credentials
+doTest.add( 'lookup - Without userId and licenseKey', async test => {
+  try {
+    const data = await pkg( {
+      endpoint: 'https://fvdm.com/u/ci_test.php?a=geoip2ws&b=',
+      timeout: config.timeout,
+    } );
+
+    test()
+      .info( 'Not using real data for this test' )
+      .isObject( 'fail', 'data', data )
+      .isObject( 'fail', 'data', data?.country )
+      .done()
+    ;
+  }
+  catch ( err ) {
+    test( err ).done();
+  }
+} );
+
+
 // Errors
 doTest.add( 'Error: from API', async test => {
   let data;


### PR DESCRIPTION
Some proxy endpoints don't need a `userId` and `licenseKey`